### PR TITLE
fix setup by copying xflux32 or xflux64 instead of renaming them

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@
 
 from distutils.core import setup
 from sys import maxsize
-from os import rename
+from shutil import copy
 
 # Determines which is the appropriate executable for 32-bit
 if maxsize == 2147483647:
-    rename("xflux32", "xflux")
+    copy("xflux32", "xflux")
 # ... or 64-bit processors
 elif maxsize == 9223372036854775807:
-    rename("xflux64", "xflux")
+    copy("xflux64", "xflux")
 
 setup(name = "f.lux indicator applet",
     version = "1.1.8",


### PR DESCRIPTION
This PR should fix issue #8, but copying files instead of renaming them.