### PR TITLE
added uninstall guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ sudo python setup.py install # OR: python setup.py install --local
 fluxgui
 
 # To uninstall:
-sudo rm /usr/local/lib/python2.7/dist-packages/f.lux_indicator*
 sudo rm -rf /usr/local/lib/python2.7/dist-packages/fluxgui
-sudo rm -rf /usr/local/share/icons/hicolor/scalable/apps/fluxgui.*
+sudo rm /usr/local/lib/python2.7/dist-packages/f.lux_indicator*
+sudo rm /usr/local/share/icons/hicolor/scalable/apps/fluxgui.*
 sudo rm /usr/share/applications/fluxgui.desktop
 sudo rm /usr/local/bin/xflux
 sudo rm /usr/local/bin/fluxgui

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ fluxgui
 
 sudo rm /usr/local/lib/python2.7/dist-packages/f.lux_indicator*
 sudo rm -rf /usr/local/lib/python2.7/dist-packages/fluxgui
-sudo rm /usr/local/lib/python2.7/dist-packages/
 sudo rm -rf /usr/local/share/icons/hicolor/scalable/apps/fluxgui.*
 sudo rm /usr/share/applications/fluxgui.desktop
 sudo rm /usr/local/bin/xflux

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ sudo rm /usr/local/lib/python2.7/dist-packages/f.lux_indicator*
 sudo rm /usr/local/share/icons/hicolor/scalable/apps/fluxgui.*
 sudo rm /usr/local/share/applications/fluxgui.desktop
 sudo rm /usr/local/bin/{xflux,fluxgui}
+rm -rf ~/.gconf/apps/fluxgui
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ fluxgui
 sudo rm -rf /usr/local/lib/python2.7/dist-packages/fluxgui
 sudo rm /usr/local/lib/python2.7/dist-packages/f.lux_indicator*
 sudo rm /usr/local/share/icons/hicolor/scalable/apps/fluxgui.*
-sudo rm /usr/share/applications/fluxgui.desktop
+sudo rm /usr/local/share/applications/fluxgui.desktop
 sudo rm /usr/local/bin/{xflux,fluxgui}
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ sudo python setup.py install # OR: python setup.py install --local
 fluxgui
 
 # To uninstall:
-sudo rm -rf /usr/local/lib/python2.7/dist-packages/fluxgui
+sudo rm -rf /usr/local/lib/python2.7/dist-packages/fluxgui/
 sudo rm /usr/local/lib/python2.7/dist-packages/f.lux_indicator*
 sudo rm /usr/local/share/icons/hicolor/scalable/apps/fluxgui.*
 sudo rm /usr/local/share/applications/fluxgui.desktop
 sudo rm /usr/local/bin/{xflux,fluxgui}
-rm -rf ~/.gconf/apps/fluxgui
+rm -rf ~/.gconf/apps/fluxgui/
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ sudo python setup.py install # OR: python setup.py install --local
 
 # Run flux
 fluxgui
+
+# To uninstall:
+
+sudo rm /usr/local/lib/python2.7/dist-packages/f.lux_indicator*
+sudo rm -rf /usr/local/lib/python2.7/dist-packages/fluxgui
+sudo rm /usr/local/lib/python2.7/dist-packages/
+sudo rm -rf /usr/local/share/icons/hicolor/scalable/apps/fluxgui.*
+sudo rm /usr/share/applications/fluxgui.desktop
+sudo rm /usr/local/bin/xflux
+sudo rm /usr/local/bin/fluxgui
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sudo rm /usr/local/bin/fluxgui
 License
 -------
 
-The f.lux indicator applet is released under the **MIT License**.
+The f.lux indicator applet is released under the [MIT License](https://github.com/xflux-gui/xflux-gui/blob/master/LICENSE).
 
 Developing
 ----------

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ sudo python setup.py install # OR: python setup.py install --local
 fluxgui
 
 # To uninstall:
-
 sudo rm /usr/local/lib/python2.7/dist-packages/f.lux_indicator*
 sudo rm -rf /usr/local/lib/python2.7/dist-packages/fluxgui
 sudo rm -rf /usr/local/share/icons/hicolor/scalable/apps/fluxgui.*

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ sudo python setup.py install # OR: python setup.py install --local
 fluxgui
 
 # To uninstall:
-sudo rm -rf /usr/local/lib/python2.7/dist-packages/fluxgui/
-sudo rm /usr/local/lib/python2.7/dist-packages/f.lux_indicator*
+sudo rm -rf /usr/local/lib/python2.7/dist-packages/{fluxgui/,f.lux_indicator*}
 sudo rm /usr/local/share/icons/hicolor/scalable/apps/fluxgui.*
 sudo rm /usr/local/share/applications/fluxgui.desktop
 sudo rm /usr/local/bin/{xflux,fluxgui}

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ sudo rm -rf /usr/local/lib/python2.7/dist-packages/fluxgui
 sudo rm /usr/local/lib/python2.7/dist-packages/f.lux_indicator*
 sudo rm /usr/local/share/icons/hicolor/scalable/apps/fluxgui.*
 sudo rm /usr/share/applications/fluxgui.desktop
-sudo rm /usr/local/bin/xflux
-sudo rm /usr/local/bin/fluxgui
+sudo rm /usr/local/bin/{xflux,fluxgui}
 ```
 
 License


### PR DESCRIPTION
* For users that installs xfluxgui manually

* Patch to close the #23 and #25 issues.

* also changed plain mit license word to clickable and redirecting to LICENSE file.

* Fixes
  - Thanks to @juanmacio for reporting the actual path of `fluxgui.desktop` in manual installation. Fixed to `/usr/local/share/applications/fluxgui.desktop`.